### PR TITLE
Bring back strict mappings test

### DIFF
--- a/lib/src/test/java/com/dmathieu/kafka/opensearch/integration/OpenSearchConnectorIT.java
+++ b/lib/src/test/java/com/dmathieu/kafka/opensearch/integration/OpenSearchConnectorIT.java
@@ -70,7 +70,7 @@ public class OpenSearchConnectorIT extends OpenSearchConnectorBaseIT {
   /**
    * Verify that mapping errors when an index has strict mapping is handled correctly
    */
-  @Test @Disabled
+  @Test
   public void testStrictMappings() throws Exception {
     helperClient.createIndex(TOPIC, "{ \"dynamic\" : \"strict\", " +
             " \"properties\": { \"longProp\": { \"type\": \"long\" } } } }");


### PR DESCRIPTION
This test was failing last week, but appears not to anymore.