### PR TITLE
Perform all flushing in a sync way

### DIFF
--- a/lib/src/main/java/com/dmathieu/kafka/opensearch/OpenSearchClient.java
+++ b/lib/src/main/java/com/dmathieu/kafka/opensearch/OpenSearchClient.java
@@ -247,6 +247,13 @@ public class OpenSearchClient {
     bulkProcessor.flush();
   }
 
+  public void waitForInFlightRequests() {
+    // TODO notify
+    while (numBufferedRecords.get() > 0) {
+      clock.sleep(WAIT_TIME_MS);
+    }
+  }
+
   /**
    * Checks whether the index already has a mapping or not.
    * @param index the index to check
@@ -565,7 +572,7 @@ public class OpenSearchClient {
    *
    * @return true if a response has failed, false if none have failed
    */
-  private boolean isFailed() {
+  public boolean isFailed() {
     return error.get() != null;
   }
 

--- a/lib/src/main/java/com/dmathieu/kafka/opensearch/OpenSearchSinkTask.java
+++ b/lib/src/main/java/com/dmathieu/kafka/opensearch/OpenSearchSinkTask.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -129,9 +130,8 @@ public class OpenSearchSinkTask extends SinkTask {
     } catch (IllegalStateException e) {
       log.debug("Tried to flush data to OpenSearch, but BulkProcessor is already closed.", e);
     }
-    Map<TopicPartition, OffsetAndMetadata> offsets = offsetTracker.offsets();
-    log.debug("preCommitting offsets {}", offsets);
-    return offsets;
+    client.waitForInFlightRequests();
+    return offsetTracker.offsets();
   }
 
   @Override

--- a/lib/src/test/java/com/dmathieu/kafka/opensearch/integration/OpenSearchConnectorIT.java
+++ b/lib/src/test/java/com/dmathieu/kafka/opensearch/integration/OpenSearchConnectorIT.java
@@ -82,6 +82,7 @@ public class OpenSearchConnectorIT extends OpenSearchConnectorBaseIT {
     connect.configureConnector(CONNECTOR_NAME, props);
     waitForConnectorToStart(CONNECTOR_NAME, TASKS_MAX);
 
+    assertThat(getConnectorOffset(CONNECTOR_NAME, TOPIC, 0)).isEqualTo(0);
     connect.kafka().produce(TOPIC, "key1", "{\"longProp\":1}");
     connect.kafka().produce(TOPIC, "key2", "{\"any-prop\":1}");
     connect.kafka().produce(TOPIC, "key3", "{\"any-prop\":1}");


### PR DESCRIPTION
This is a (maybe) temporary fix to allow syncing with a topic-mutating SMT (such as the timestamp one).
It's heavily inspired from https://github.com/confluentinc/kafka-connect-elasticsearch/pull/589, but without the configuration.