### PR TITLE
Add test for storing offsets with a topic-mutating smt

### DIFF
--- a/lib/src/test/java/com/dmathieu/kafka/opensearch/integration/OpenSearchConnectorIT.java
+++ b/lib/src/test/java/com/dmathieu/kafka/opensearch/integration/OpenSearchConnectorIT.java
@@ -106,7 +106,11 @@ public class OpenSearchConnectorIT extends OpenSearchConnectorBaseIT {
 
     // The framework commits offsets right before failing the task, verify the failed record's
     // offset is properly included and we can move on
-    assertThat(getConnectorOffset(CONNECTOR_NAME, TOPIC, 0)).isEqualTo(2);
+    TestUtils.waitForCondition(
+        () -> getConnectorOffset(CONNECTOR_NAME, TOPIC, 0) == 2,
+        COMMIT_MAX_DURATION_MS,
+        "Connector tasks did store offsets in time."
+        );
   }
 
   @Test


### PR DESCRIPTION
To prevent regression of the issue fixed in #22, and possibly bring back the offset tracker later on.